### PR TITLE
Avoid GPG passphrase prompt for sign-build if PASSPHRASE env present

### DIFF
--- a/asserts/gpgkeypairmgr.go
+++ b/asserts/gpgkeypairmgr.go
@@ -257,7 +257,15 @@ func (gkm *GPGKeypairManager) Get(keyID string) (PrivateKey, error) {
 }
 
 func (gkm *GPGKeypairManager) sign(fingerprint string, content []byte) (*packet.Signature, error) {
-	out, err := gkm.gpg(content, "--personal-digest-preferences", "SHA512", "--default-key", "0x"+fingerprint, "--detach-sign")
+	var args []string 
+	passphrase := os.Getenv("PASSPHRASE")
+	if passphrase != "" {
+		args = []string{"--personal-digest-preferences", "SHA512", "--default-key", "0x"+fingerprint, "--pinentry-mode=loopback", "--passphrase", passphrase, "--detach-sign"}
+	} else {
+		args = []string{"--personal-digest-preferences", "SHA512", "--default-key", "0x"+fingerprint, "--detach-sign"}
+	}
+	
+	out, err := gkm.gpg(content, args...)
 	if err != nil {
 		return nil, fmt.Errorf("cannot sign using GPG: %v", err)
 	}


### PR DESCRIPTION
Currently, we are required to pass the GPG key passphrase through a pin
entry pop-up only. Therefore, it's not possible to use 'snap sign-build'
command to sign snap builds through CLI only.
This solution proposes using PASSPHRASE environment variable, if present
on system, to sign the builds. This would help signing snap builds on
CI systems as well.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
